### PR TITLE
fix: disable POW for testnet and guard against null powBlocks

### DIFF
--- a/src/cmd/pos.cmd.ts
+++ b/src/cmd/pos.cmd.ts
@@ -1908,7 +1908,7 @@ export class PosCMD extends CMD {
       if (blk.blockType == 'KBlock') {
         if (config.powEnabled) {
           const epochInfo = await this.pos.getEpochInfo(blk.qc.epochID);
-          for (const pb of epochInfo.powBlocks) {
+          for (const pb of (epochInfo.powBlocks || [])) {
             powBlocks.push({ ...pb, beneficiary: pb.Beneficiary || pb.beneficiary });
           }
         }

--- a/src/const/index.ts
+++ b/src/const/index.ts
@@ -161,7 +161,7 @@ export const GetNetworkConfig = (net: Network): NetworkConfig | undefined => {
         stMTRGAddress: '',
         stMTRG_MTRG_Pair: '',
 
-        powEnabled: true,
+        powEnabled: false,
         auctionEnabled: true,
         sourcifyEnabled: true,
 


### PR DESCRIPTION
## Summary
- Set `powEnabled: false` for `TestNet` in `src/const/index.ts` — testnet has no POW blocks, so the previous `true` value caused KBlock processing to call `getEpochInfo` unnecessarily
- Add `|| []` null-guard on `epochInfo.powBlocks` in `src/cmd/pos.cmd.ts` to prevent a TypeError crash if the field is ever absent

## Test plan
- [ ] Run POS scanner against testnet and verify KBlocks are processed without errors
- [ ] Confirm `powBlocks` is stored as `[]` on KBlocks (no crash, no stale POW data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)