### PR TITLE
feat: add separate docker-compose files for mainnet and testnet sync services

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -1,0 +1,30 @@
+services:
+  sync-pos:
+    image: meterio/scan-api:latest
+    env_file: .env.mainnet
+    command: ["sync", "pos", "-n", "main"]
+    restart: unless-stopped
+
+  sync-pow:
+    image: meterio/scan-api:latest
+    env_file: .env.mainnet
+    command: ["sync", "pow", "-n", "main"]
+    restart: unless-stopped
+
+  sync-nft:
+    image: meterio/scan-api:latest
+    env_file: .env.mainnet
+    command: ["sync", "nft", "-n", "main"]
+    restart: unless-stopped
+
+  sync-metric:
+    image: meterio/scan-api:latest
+    env_file: .env.mainnet
+    command: ["sync", "metric", "-n", "main"]
+    restart: unless-stopped
+
+  sync-scriptengine:
+    image: meterio/scan-api:latest
+    env_file: .env.mainnet
+    command: ["sync", "scriptengine", "-n", "main"]
+    restart: unless-stopped

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -1,0 +1,24 @@
+services:
+  sync-pos:
+    image: meterio/scan-api:latest
+    env_file: .env.testnet
+    command: ["sync", "pos", "-n", "test"]
+    restart: unless-stopped
+
+  sync-nft:
+    image: meterio/scan-api:latest
+    env_file: .env.testnet
+    command: ["sync", "nft", "-n", "test"]
+    restart: unless-stopped
+
+  sync-metric:
+    image: meterio/scan-api:latest
+    env_file: .env.testnet
+    command: ["sync", "metric", "-n", "test"]
+    restart: unless-stopped
+
+  sync-scriptengine:
+    image: meterio/scan-api:latest
+    env_file: .env.testnet
+    command: ["sync", "scriptengine", "-n", "test"]
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- Add `docker-compose.mainnet.yml` with sync services: `pos`, `pow`, `nft`, `metric`, `scriptengine`
- Add `docker-compose.testnet.yml` with sync services: `pos`, `nft`, `metric`, `scriptengine` (pow excluded as it's disabled on testnet)
- Each file reads from its own env file (`.env.mainnet` / `.env.testnet`) to allow independent configuration

## Usage
```bash
docker compose -f docker-compose.mainnet.yml up -d
docker compose -f docker-compose.testnet.yml up -d
```

## Test plan
- [ ] Copy `.env.sample` to `.env.mainnet` and `.env.testnet` and fill in credentials
- [ ] Verify mainnet sync services start correctly with `docker compose -f docker-compose.mainnet.yml up`
- [ ] Verify testnet sync services start correctly with `docker compose -f docker-compose.testnet.yml up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)