### PR TITLE
fix: add distinct project names to prevent container name conflicts

### DIFF
--- a/docker-compose.mainnet.yml
+++ b/docker-compose.mainnet.yml
@@ -1,3 +1,5 @@
+name: scan-mainnet
+
 services:
   sync-pos:
     build:

--- a/docker-compose.testnet.yml
+++ b/docker-compose.testnet.yml
@@ -1,3 +1,5 @@
+name: scan-testnet
+
 services:
   sync-pos:
     build:


### PR DESCRIPTION
## Summary

When running mainnet and testnet compose files simultaneously, Docker used the same project name (directory name) causing container names to collide — only one group of containers would be up.

## Changes

- `docker-compose.mainnet.yml`: added `name: scan-mainnet`
- `docker-compose.testnet.yml`: added `name: scan-testnet`

Containers are now named distinctly:
- Mainnet: `scan-mainnet-sync-pos-1`, `scan-mainnet-sync-pow-1`, ...
- Testnet: `scan-testnet-sync-pos-1`, `scan-testnet-sync-nft-1`, ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)